### PR TITLE
Add support for installing the snapshot on Linux

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ runs:
 
   steps:
     - name: Install Swift ${{ inputs.tag }}
+      if: ${{ runner.os == 'Windows' }}
       run: |
         function Update-EnvironmentVariables {
           foreach ($level in "Machine", "User") {
@@ -34,3 +35,36 @@ runs:
         echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
       shell: pwsh
+
+    - name: Install Swift ${{ inputs.tag }}
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        pushd /tmp
+
+        case $(lsb_release -is) in
+        Ubuntu)
+          case $(lsb_release -rs) in
+          16.04)
+            curl -sOL https://download.swift.org/${{ inputs.branch }}/ubuntu1604/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-ubuntu16.04.tar.gz
+            tar zxf swift-${{ inputs.tag }}-ubuntu16.04.tar.gz -C ${HOME}
+          ;;
+          18.04)
+            curl -sOL https://download.swift.org/${{ inputs.branch }}/ubuntu1804/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-ubuntu18.04.tar.gz
+            tar zxf swift-${{ inputs.tag }}-ubuntu18.04.tar.gz -C ${HOME}
+          ;;
+          20.04)
+            curl -sOL https://download.swift.org/${{ inputs.branch }}/ubuntu2004/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-ubuntu20.04.tar.gz
+            tar zxf swift-${{ inputs.tag }}-ubuntu20.04.tar.gz -C ${HOME}
+          ;;
+          *)
+            echo ::error unsupported Ubuntu release
+            exit 1
+          esac
+        ;;
+        *)
+          echo ::error unknown Linux distribution
+          exit 1
+        esac
+
+        echo "${HOME}/usr/bin" >> $GITHUB_PATH
+      shell: bash


### PR DESCRIPTION
Add support for installing Swift snapshots on Linux in addition to
Windows.  This only currently supports Ubuntu runners.  Adding
additional runners is easily extended, but I do not believe that they
are available without self-hosted runners.