### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,18 @@ runs:
         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
       shell: pwsh
 
+    - name: VS2022 Compatibility Setup
+      if: ${{ runner.os == 'Windows' }}
+      uses: seanmiddleditch/gha-setup-vsdevenv@master
+    - name: VS2022 Compatibility Installation
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        Copy-Item "$env:SDKROOT\usr\share\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
+        Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
+        Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
+        Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+      shell: pwsh
+
     - name: Install Swift ${{ inputs.tag }}
       if: ${{ runner.os == 'Linux' }}
       run: |


### PR DESCRIPTION
Adjust the install action to account for VS2022 changes.  The older releases do not properly install with multiple installed toolsets with VS2022 due to the v143 toolset not being setup but being the default.  This restores the old copy path to accommodate the mult-toolset scenario.