### PR TITLE
Allow installation on Ubuntu 22.04

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
         Ubuntu)
           release=$(lsb_release -rs)
           case ${release} in
-          16.04|18.04|20.04)
+          16.04|18.04|20.04|22.04)
             curl -sOL https://download.swift.org/${{ inputs.branch }}/ubuntu${release/./}/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-ubuntu${release}.tar.gz
             tar zxf swift-${{ inputs.tag }}-ubuntu${release}.tar.gz -C ${HOME}
             rm -f swift-${{ inputs.tag }}-ubuntu${release}.tar.gz


### PR DESCRIPTION
The Swift 5.7 release supports Ubuntu 22.04. This PR adds 22.04 to the allowed versions