### PR TITLE
use compnerd/gha-setup-vsdevenv

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - name: VS2022 Compatibility Setup
       if: ${{ runner.os == 'Windows' }}
-      uses: seanmiddleditch/gha-setup-vsdevenv@master
+      uses: compnerd/gha-setup-vsdevenv@main
     - name: VS2022 Compatibility Installation
       if: ${{ runner.os == 'Windows' }}
       run: |


### PR DESCRIPTION
use compnerd/gha-setup-vsdevenv to silence warning about deprecated github feature: 

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```