### PR TITLE
Add a simple workflow test

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -1,7 +1,7 @@
 name: Windows - test
 
 on:
-  workflow_call:
+  workflow_dispatch:
 
 env:
   BUILD_PRESET: debug

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -1,0 +1,23 @@
+name: Windows - test
+
+on:
+  workflow_call:
+
+env:
+  BUILD_PRESET: debug
+
+jobs:
+  build-on-win:
+    runs-on: windows-2022
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Swift
+      uses: ./
+      with:
+        branch: development
+        tag: DEVELOPMENT-SNAPSHOT-2023-05-20-a
+
+    - name: check swift version
+      run: swift --version


### PR DESCRIPTION
Add a simple workflow test that runs this action on demand, installs swift toolchain on windows and executes `swift --version`.

In a future PR I will change this to be executed on every pull request. For now it has to be triggered manually in the Actions tab, `Run Workflow` command.
