### PR TITLE
deps: Pin compnerd/gha-setup-vsdevenv to SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
 
     - name: VS2022 Compatibility Setup
       if: runner.os == 'Windows'
-      uses: compnerd/gha-setup-vsdevenv@9f8415157e5026ac14042568f39b8b3ac643cc72
+      uses: compnerd/gha-setup-vsdevenv@9f8415157e5026ac14042568f39b8b3ac643cc72 # v4
 
     - name: VS2022 Compatibility Installation
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
 
     - name: VS2022 Compatibility Setup
       if: runner.os == 'Windows'
-      uses: compnerd/gha-setup-vsdevenv@main
+      uses: compnerd/gha-setup-vsdevenv@9f8415157e5026ac14042568f39b8b3ac643cc72
 
     - name: VS2022 Compatibility Installation
       if: runner.os == 'Windows'


### PR DESCRIPTION
Some security policies require all external GitHub Actions to be pinned
to a specific SHA. This typically also applies to transitive
dependencies.

Usage of `dsaltares/fetch-gh-release-asset` is already pinned, so
pinning the only other GHA allows for safely pinning this action as
well.
