### PR TITLE
Use gh instead of dsaltares/fetch-gh-release-asset to fetch asset

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,14 +53,15 @@ runs:
           exit 1
         fi
 
-    - name: Fetch installer from Github release
-      uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4  # pinned commit for v1.1
+    - name: Fetch installer from GitHub release
       if: steps.validation.outputs.use_custom_url == 1
-      with:
-        repo: '${{ inputs.github-repo }}'
-        version: 'tags/${{ inputs.release-tag-name }}'
-        file: '${{ inputs.release-asset-name }}'
-        token: ${{ inputs.github-token }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        gh release download "${{ inputs.release-tag-name }}" \
+          --repo "${{ inputs.github-repo }}" \
+          --pattern "${{ inputs.release-asset-name }}"
 
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'


### PR DESCRIPTION
The action `dsaltares/fetch-gh-release-asset` appears to be abandoned. There hasn't been a release in about a year and the maintainer is not responding to requests to update to using Node 20. This is a problem because [GitHub has deprecated Node 16 and will remove it in Spring 2024](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Instead, let's just use the `gh` CLI directly which can do the same as `dsaltares/fetch-gh-release-asset`, especially in the simple method we are using it within this action.
