### PR TITLE
exit 1 when Start-Process throws

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,8 @@ runs:
             }
           } catch {
             $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
-            Write-Host "Installation failed after $Duration seconds"
+            Write-Host "Installation failed after $Duration seconds: $_"
+            exit 1
           }
         }
 


### PR DESCRIPTION
The catch block swallowed the error, resulting in a silent failure while the action succeeded.