### PR TITLE
Fix tests to use an installer that supports arguments

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -53,7 +53,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2023-05-20-a
+        tag: DEVELOPMENT-SNAPSHOT-2024-08-07-a # This installer version supports the argument below
         installer-args: OptionsInstallIde=0 
 
     - name: Assert that we find swiftc.exe

--- a/action.yml
+++ b/action.yml
@@ -203,6 +203,7 @@ runs:
           $InstallArgs += "${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
           $StartTime = Get-Date
+          Write-Host "Installer args: $($InstallArgs -join ' ')"
           Write-Host "Starting Install..."
           try {
             $Process = Start-Process -FilePath $FilePath -ArgumentList $InstallArgs -Wait -PassThru -Verb RunAs


### PR DESCRIPTION
Older installers did not have options for installing only certain components. Also adds printing the arguments.