### PR TITLE
action: simplify the action logic

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -43,7 +43,9 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y ninja-build
 
     - name: Smoke test
-      run: cmake -GNinja -S .github/smoke-test -B .cmake-build && cmake --build .cmake-build
+      run: |
+        cmake -B build -G Ninja -S .github/smoke-test
+        cmake --build build
 
   windows-installer-args:
     name: Test installer arguments on Windows
@@ -61,10 +63,9 @@ jobs:
         installer-args: OptionsInstallIDE=0 
 
     - name: Assert that we find swiftc.exe
-      run: where.exe swiftc.exe
+      run: Get-Command swiftc.exe
 
     - name: Assert that we don't find sourcekit-lsp.exe
       shell: pwsh
       run: |
-        where.exe sourcekit-lsp.exe
-        if ($LastExitCode -eq 0) { exit 1 }
+        -not (Get-Command sourcekit-lsp.exe -ErrorAction SilebtlyContinue)

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -29,7 +29,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2025-02-28-a
+        tag: DEVELOPMENT-SNAPSHOT-2025-02-24-a
 
     - name: Check Swift version
       run: swift --version
@@ -59,7 +59,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2025-02-28-a
+        tag: DEVELOPMENT-SNAPSHOT-2025-02-24-a
         installer-args: OptionsInstallIDE=0 
 
     - name: Assert that we find swiftc.exe

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -68,4 +68,4 @@ jobs:
     - name: Assert that we don't find sourcekit-lsp.exe
       shell: pwsh
       run: |
-        -not (Get-Command sourcekit-lsp.exe -ErrorAction SilebtlyContinue)
+        -not (Get-Command sourcekit-lsp.exe -ErrorAction SilentlyContinue)

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -29,7 +29,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2023-05-20-a
+        tag: DEVELOPMENT-SNAPSHOT-2025-04-03-a
 
     - name: Check Swift version
       run: swift --version
@@ -57,8 +57,8 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2024-08-07-a # This installer version supports the argument below
-        installer-args: OptionsInstallIde=0 
+        tag: DEVELOPMENT-SNAPSHOT-2025-04-03-a
+        installer-args: OptionsInstallIDE=0 
 
     - name: Assert that we find swiftc.exe
       run: where.exe swiftc.exe

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -29,7 +29,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2025-04-03-a
+        tag: DEVELOPMENT-SNAPSHOT-2024-08-07-a
 
     - name: Check Swift version
       run: swift --version
@@ -59,7 +59,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2025-04-03-a
+        tag: DEVELOPMENT-SNAPSHOT-2024-08-07-a
         installer-args: OptionsInstallIDE=0 
 
     - name: Assert that we find swiftc.exe

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -29,7 +29,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2024-08-07-a
+        tag: DEVELOPMENT-SNAPSHOT-2025-02-28-a
 
     - name: Check Swift version
       run: swift --version
@@ -59,7 +59,7 @@ jobs:
       uses: ./
       with:
         branch: development
-        tag: DEVELOPMENT-SNAPSHOT-2024-08-07-a
+        tag: DEVELOPMENT-SNAPSHOT-2025-02-28-a
         installer-args: OptionsInstallIDE=0 
 
     - name: Assert that we find swiftc.exe

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: pwsh
 
     - name: Fetch installer from swift.org
-      if: runner.os == 'Windows' && ${{ inputs.source }} == 'swift.org'
+      if: runner.os == 'Windows' && inputs.source == 'swift.org'
       run: |
         $URL = if ("${{ inputs.build_arch }}" -eq "amd64") {
           "https://download.swift.org/${{ inputs.branch }}/windows10/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10.exe"

--- a/action.yml
+++ b/action.yml
@@ -125,10 +125,10 @@ runs:
         }
 
         foreach ($level in "Machine", "User") {
-          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
             # For Path variables, append the new values, if they're not already in there
-            if ($_.Name -Match 'Path$') {
-              $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+            if ($_.Name -eq 'Path') {
+              $_.Value = ("${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
             }
             $_
           } | Set-Content -Path { "Env:$($_.Name)" }

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
 
     - name: Fetch installer from swift.org
       id: fetch-installer-1
-      if: inputs.source == 'swift.org'
+      if: ${{ inputs.source }} == 'swift.org'
       run: |
         $URL = if ("${{ inputs.build_arch }}" -eq "amd64") {
           "https://download.swift.org/${{ inputs.branch }}/windows10/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10.exe"

--- a/action.yml
+++ b/action.yml
@@ -150,7 +150,7 @@ runs:
         source /etc/os-release
         echo ${ID} ${VERSION_ID}
         case ${ID} in
-        Ubuntu)
+        ubuntu)
           case ${VERSION_ID} in
           16.04|18.04|20.04|22.04|24.04)
             if [[ "${{ steps.validation.outputs.use_custom_url }}" == "1" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -98,8 +98,8 @@ runs:
         foreach ($level in "Machine", "User") {
           [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
             # For Path variables, append the new values, if they're not already in there
-            if ($_.Name -match 'Path$') {
-              $_.Value = "${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
+            if ($_.Name -eq "Path") {
+              $_.Value = ("${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
             }
             $_
           } | Set-Content -Path { "Env:$($_.Name)" }

--- a/action.yml
+++ b/action.yml
@@ -52,8 +52,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        gh release download --skip-existing "${{ inputs.release-tag-name }}" --repo "${{ inputs.github-repo }}" --pattern "${{ inputs.release-asset-name }}" --dir ${env:Temp}
-        installer-path=[IO.Path]::Combine(${env:Temp}, ${{ inputs.release-asset-name }}) | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        gh release download "${{ inputs.release-tag-name }}" --skip-existing --repo "${{ inputs.github-repo }}" --pattern "${{ inputs.release-asset-name }}" --output $([IO.Path]::Combine(${env:Temp}, "installer.exe"))
       shell: pwsh
 
     - name: Fetch installer from swift.org
@@ -66,18 +65,11 @@ runs:
           "https://download.swift.org/${{ inputs.branch }}/windows10-${{ inputs.build_arch }}/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10-${{ inputs.build_arch }}.exe"
         }
 
-        $InvalidCharacters = [IO.Path]::GetInvalidFileNameChars() -Join ''
-        $RE = "[{0}]" -f [RegEx]::Escape($InvalidCharacters)
-        $FileName = [IO.Path]::GetFileName($URL) -Replace $RE
-
-        if ([String]::IsNullOrEmpty($FileName)) {
-          $FileName = [IO.Path]::GetRandomFileName()
-        }
-        $Path = [IO.Path]::Combine(${env:Temp}, $FileName)
-
-        Write-Host "Downloading package from $URL to $Path..."
+        $Path = [IO.Path]::Combine(${env:Temp}, "installer.exe")
         $Retries = 3
         $RetryInterval = 30
+
+        Write-Host "Downloading package from $URL to $Path..."
         do {
           try {
             $AttemptStartTime = Get-Date
@@ -99,24 +91,25 @@ runs:
           Write-Host "::warning::Waiting $RetryInterval seconds before retrying (retries remaining: $($Retries - 1))..."
           Start-Sleep -Seconds $RetryInterval
         } while (--$Retries -gt 0)
-
-        Write-Output installer-path=$Path | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
       shell: pwsh
 
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'
       run: |
+        $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
         $Arguments = "${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
-        $Installer = "${{ steps.fetch-installer-0.outputs.installer-path || steps.fetch-installer-1.outputs.installer-path }}"
 
-        $StartTime = Get-Date
+        Write-Host "::debug::Installer: $Installer"
         Write-Host "::debug::Installer Arguments: $($Arguments -join ' ')"
         Write-Host "::debug::Starting Install ..."
+        $StartTime = Get-Date
         try {
-          $Process = Start-Process -FilePath "$Installer" -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
+          $Process = Start-Process -FilePath $Installer -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
           $ExitCode = $Process.ExitCode
-          $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
+          $StopTime = Get-Date
+
+          $Duration = [math]::Round(($StopTime - $StartTime).TotalSeconds, 2)
           switch ($ExitCode) {
             0 { Write-Host "::debug::Installation successful in $Duration seconds" }
             3010 { Write-Host "::notice::Installation successful in $Duration seconds; reboot required"}

--- a/action.yml
+++ b/action.yml
@@ -147,6 +147,7 @@ runs:
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Linux'
       run: |
+        cat /etc/os-release
         source /etc/os-release
         case ${ID} in
         ubuntu)

--- a/action.yml
+++ b/action.yml
@@ -147,10 +147,10 @@ runs:
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Linux'
       run: |
-        cat /etc/os-release
         source /etc/os-release
+        echo ${ID} ${VERSION_ID}
         case ${ID} in
-        ubuntu)
+        Ubuntu)
           case ${VERSION_ID} in
           16.04|18.04|20.04|22.04|24.04)
             if [[ "${{ steps.validation.outputs.use_custom_url }}" == "1" ]]; then
@@ -162,7 +162,7 @@ runs:
             rm -f swift-toolchain.tar.gz
           ;;
           *)
-            echo "::error file=/etc/os-release,title=Unsupported::unsupported ${OS} release (${VERSION_ID})"
+            echo "::error file=/etc/os-release,title=Unsupported::unsupported ${ID} release (${VERSION_ID})"
             exit 1
           esac
         ;;

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
         try {
           (New-Object System.Net.WebClient).DownloadFile($URL, $Path)
         } catch {
-          Write-Host "::error::Package download failed: $(_.Exception.Message)"
+          Write-Host "::error::Package download failed: $($_.Exception.Message)"
         }
       shell: pwsh
 

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,6 @@ runs:
   using: 'composite'
   steps:
     - name: Fetch installer from GitHub release
-      id: fetch-installer-0
       if: inputs.source == 'custom'
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -56,7 +55,6 @@ runs:
       shell: pwsh
 
     - name: Fetch installer from swift.org
-      id: fetch-installer-1
       if: ${{ inputs.source }} == 'swift.org'
       run: |
         $URL = if ("${{ inputs.build_arch }}" -eq "amd64") {
@@ -125,12 +123,12 @@ runs:
         }
 
         foreach ($level in "Machine", "User") {
-          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
+          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
             # For Path variables, append the new values, if they're not already in there
-            Write-Host "New Path: $($_.Value)"
             if ($_.Name -eq 'Path') {
               $_.Value = ("${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
             }
+            Write-Host "$_.Value"
             $_
           } | Set-Content -Path { "Env:$($_.Name)" }
         }

--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,7 @@ runs:
         } while (--$Retries -gt 0)
 
         installer-path=$Path | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+      shell: pwsh
 
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -76,18 +76,6 @@ runs:
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'
       run: |
-        function Update-EnvironmentVariables {
-          foreach ($level in "Machine", "User") {
-            [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-              # For Path variables, append the new values, if they're not already in there
-              if ($_.Name -Match 'Path$') {
-                $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-              }
-              $_
-            } | Set-Content -Path { "Env:$($_.Name)" }
-          }
-        }
-
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
         $Arguments = "/quiet ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
@@ -103,15 +91,23 @@ runs:
             }
           }
         } catch {
-          Write-Host "::error::Installation failed $_"
+          Write-Host "::error::Installation failed: $($_.Exception.Message)"
           exit 1
         }
 
-        Update-EnvironmentVariables
+        foreach ($level in "Machine", "User") {
+          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
+            # For Path variables, append the new values, if they're not already in there
+            if ($_.Name -eq "Path") {
+              $_.Value = "${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
+            }
+            $_
+          } | Set-Content -Path { "Env:$($_.Name)" }
+        }
 
         # Reset Path and environment
         Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-        Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
+        Get-ChildItem Env: | ForEach-Object { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
       shell: pwsh
 
     - name: Check Swift version

--- a/action.yml
+++ b/action.yml
@@ -127,6 +127,7 @@ runs:
         foreach ($level in "Machine", "User") {
           [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
             # For Path variables, append the new values, if they're not already in there
+            Write-Host "New Path: $($_.Value)"
             if ($_.Name -eq 'Path') {
               $_.Value = ("${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
             }

--- a/action.yml
+++ b/action.yml
@@ -64,81 +64,50 @@ runs:
         }
 
         $Path = [IO.Path]::Combine(${env:Temp}, "installer.exe")
-        $Retries = 3
-        $RetryInterval = 30
 
         Write-Host "Downloading package from $URL to $Path..."
-        do {
-          try {
-            $AttemptStartTime = Get-Date
-            (New-Object System.Net.WebClient).DownloadFile($URL, $Path)
-            $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
-            Write-Host "::debug::Package downloaded in $AttemptDuration seconds"
-            break
-          } catch {
-            $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
-            Write-Host "::error::Package download failed after $AttemptDuration seconds"
-            Write-Host "::error::$($_.Exception.Message)"
-          }
-
-          if ($Retries -eq 1) {
-            $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
-            throw "Package download failed after $Duration seconds"
-          }
-
-          Write-Host "::warning::Waiting $RetryInterval seconds before retrying (retries remaining: $($Retries - 1))..."
-          Start-Sleep -Seconds $RetryInterval
-        } while (--$Retries -gt 0)
+        try {
+          (New-Object System.Net.WebClient).DownloadFile($URL, $Path)
+        } catch {
+          Write-Host "::error::Package download failed: $(_.Exception.Message)"
+        }
       shell: pwsh
 
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'
       run: |
-        function Update-EnvironmentVariables {
-          foreach ($level in "Machine", "User") {
-            [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-              # For Path variables, append the new values, if they're not already in there
-              if ($_.Name -Match 'Path$') {
-                $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-              }
-              $_
-            } | Set-Content -Path { "Env:$($_.Name)" }
-          }
-        }
-
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
         $Arguments = "/quiet ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
-        Write-Host "::debug::Installer: $Installer"
         Write-Host "::debug::Installer Arguments: $($Arguments -join ' ')"
-        Write-Host "::debug::Starting Install ..."
-        $StartTime = Get-Date
         try {
           $Process = Start-Process -FilePath $Installer -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
-          $ExitCode = $Process.ExitCode
-          $StopTime = Get-Date
-
-          $Duration = [math]::Round(($StopTime - $StartTime).TotalSeconds, 2)
-          switch ($ExitCode) {
-            0 { Write-Host "::debug::Installation successful in $Duration seconds" }
-            3010 { Write-Host "::notice::Installation successful in $Duration seconds; reboot required"}
+          switch ($Process.ExitCode) {
+            0 { Write-Host "::debug::Installation successful" }
+            3010 { Write-Host "::notice::Installation successful; reboot required"}
             default {
-              Write-Host "::error::Installation process returned unexpected exit code: $ExitCode"
-              Write-Host "::debug::Time elapsed: $Duration seconds"
-              exit $ExitCode
+              Write-Host "::error::Installation process returned unexpected exit code: $_"
+              exit $_
             }
           }
         } catch {
-          $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
-          Write-Host "::error::Installation failed after $Duration seconds: $_"
+          Write-Host "::error::Installation failed $_"
           exit 1
         }
 
-        Update-EnvironmentVariables
+        foreach ($level in "Machine", "User") {
+          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
+            # For Path variables, append the new values, if they're not already in there
+            if ($_.Name -eq 'Path') {
+              $_.Value = ("${env:Path};$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+            }
+            $_
+          } | Set-Content -Path { "Env:$($_.Name)" }
+        }
 
         # Reset Path and environment
-        Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-        Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
+        Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding UTF8
+        Get-ChildItem Env: | ForEach-Object { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding UTF8 }
       shell: pwsh
 
     - name: Check Swift version
@@ -146,24 +115,9 @@ runs:
       id: swift-version
       run: |
         & swift --version
-        $SwiftVersionOutput=$(swift --version)
-        if ("$SwiftVersionOutput" -match "[\d]+(\.[\d]+){0,2}") {
-          $SwiftSemVer=$Matches[0]
-
-          # Ensure we have at least MAJOR.MINOR or [System.Version] won't parse.
-          if (-Not ($SwiftSemVer -like "*.*")) {
-            $SwiftSemVer += ".0"
-          }
-
-          $SwiftVersion=[System.Version]($SwiftSemVer)
-
-          # If the toolchain is newer than 5.9 we don't need to ensure compatibility with VS2022.
-          if ($SwiftVersion -gt [System.Version]"5.9") {
-            "is_newer_than_5_9='true'" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
-          } else {
-            "is_newer_than_5_9='false'" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
-          }
-        }
+        $Matches = $(swift --version) -match "\d+.\d+\(.\d+)?"
+        $SwiftVersion = [System.Version]($Matches[0])
+        Write-Output is_newer_than_5_9=$($SwiftVersion -gt [System.Version]"5.9") | Out-File $env:GITHUB_OUTPUT -Append -Encoding UTF8
       shell: pwsh
 
     - name: VS2022 Compatibility Setup

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,18 @@ runs:
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'
       run: |
+        function Update-EnvironmentVariables {
+          foreach ($level in "Machine", "User") {
+            [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+              # For Path variables, append the new values, if they're not already in there
+              if ($_.Name -Match 'Path$') {
+                $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+              }
+              $_
+            } | Set-Content -Path { "Env:$($_.Name)" }
+          }
+        }
+
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
         $Arguments = "/quiet ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
@@ -95,19 +107,11 @@ runs:
           exit 1
         }
 
-        foreach ($level in "Machine", "User") {
-          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
-            # For Path variables, append the new values, if they're not already in there
-            if ($_.Name -eq 'Path') {
-              $_.Value = ("${env:Path};$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-            }
-            $_
-          } | Set-Content -Path { "Env:$($_.Name)" }
-        }
+        Update-EnvironmentVariables
 
         # Reset Path and environment
-        Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding UTF8
-        Get-ChildItem Env: | ForEach-Object { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding UTF8 }
+        Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+        Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
       shell: pwsh
 
     - name: Check Swift version

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: pwsh
 
     - name: Fetch installer from swift.org
-      if: ${{ inputs.source }} == 'swift.org'
+      if: runner.os == 'Windows' && ${{ inputs.source }} == 'swift.org'
       run: |
         $URL = if ("${{ inputs.build_arch }}" -eq "amd64") {
           "https://download.swift.org/${{ inputs.branch }}/windows10/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10.exe"
@@ -119,8 +119,9 @@ runs:
       id: swift-version
       run: |
         $Output = swift --version
-        if ($Output -match "\d+.\d+\(.\d+)?") {
-          $SwiftVersion = [System.Version]($Matches[0])
+        $Match = ([regex]"\d+.\d+(.\d+)?").Match($Output)
+        if ($Match.Success) {
+          $SwiftVersion = [System.Version]($Match.Groups[0].Value)
           Write-Output is_newer_than_5_9=$($SwiftVersion -gt [System.Version]"5.9") | Out-File $env:GITHUB_OUTPUT -Append -Encoding UTF8
         }
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -83,12 +83,12 @@ runs:
             $AttemptStartTime = Get-Date
             (New-Object System.Net.WebClient).DownloadFile($URL, $Path)
             $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
-            Write-Host "Package downloaded in $AttemptDuration seconds"
+            Write-Host "::debug::Package downloaded in $AttemptDuration seconds"
             break
           } catch {
             $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
-            Write-Warning "Package download failed after $AttemptDuration seconds"
-            Write-Warning $_.Exception.Message
+            Write-Host "::error::Package download failed after $AttemptDuration seconds"
+            Write-Host "::error::$($_.Exception.Message)"
           }
 
           if ($Retries -eq 1) {
@@ -96,7 +96,7 @@ runs:
             throw "Package download failed after $Duration seconds"
           }
 
-          Write-Warning "Waiting $RetryInterval seconds before retrying (retries remaining: $($Retries - 1))..."
+          Write-Host "::warning::Waiting $RetryInterval seconds before retrying (retries remaining: $($Retries - 1))..."
           Start-Sleep -Seconds $RetryInterval
         } while (--$Retries -gt 0)
 
@@ -108,27 +108,27 @@ runs:
       run: |
         $Arguments = "${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
-        $Installer = ${{ steps.fetch-installer-0.outputs.installer-path || steps.fetch-installer-1.outputs.installer-path }}
+        $Installer = "${{ steps.fetch-installer-0.outputs.installer-path || steps.fetch-installer-1.outputs.installer-path }}"
 
         $StartTime = Get-Date
-        Write-Host "Installer Arguments: $($Arguments -join ' ')"
-        Write-Host "Starting Install..."
+        Write-Host "::debug::Installer Arguments: $($Arguments -join ' ')"
+        Write-Host "::debug::Starting Install ..."
         try {
-          $Process = Start-Process -FilePath $Installer -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
+          $Process = Start-Process -FilePath "$Installer" -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
           $ExitCode = $Process.ExitCode
           $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
           switch ($ExitCode) {
-            0 { Write-Host "Installation successful in $Duration seconds" }
-            3010 { Write-Host "Installation successful in $Duration seconds; reboot required"}
+            0 { Write-Host "::debug::Installation successful in $Duration seconds" }
+            3010 { Write-Host "::notice::Installation successful in $Duration seconds; reboot required"}
             default {
-              Write-Host "Installation process returned unexpected exit code: $ExitCode"
-              Write-Host "Time elapsed: $Duration seconds"
+              Write-Host "::error::Installation process returned unexpected exit code: $ExitCode"
+              Write-Host "::debug::Time elapsed: $Duration seconds"
               exit $ExitCode
             }
           }
         } catch {
           $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
-          Write-Host "Installation failed after $Duration seconds: $_"
+          Write-Host "::error::Installation failed after $Duration seconds: $_"
           exit 1
         }
 

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,18 @@ runs:
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'
       run: |
+        function Update-EnvironmentVariables {
+          foreach ($level in "Machine", "User") {
+            [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+              # For Path variables, append the new values, if they're not already in there
+              if ($_.Name -Match 'Path$') {
+                $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+              }
+              $_
+            } | Set-Content -Path { "Env:$($_.Name)" }
+          }
+        }
+
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
         $Arguments = "/quiet ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
@@ -122,16 +134,7 @@ runs:
           exit 1
         }
 
-        foreach ($level in "Machine", "User") {
-          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-            # For Path variables, append the new values, if they're not already in there
-            if ($_.Name -eq 'Path') {
-              $_.Value = ("${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
-            }
-            Write-Host "$_.Value"
-            $_
-          } | Set-Content -Path { "Env:$($_.Name)" }
-        }
+        Update-EnvironmentVariables
 
         # Reset Path and environment
         Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
 
 runs:
   using: 'composite'
-
+  steps:
     - name: Fetch installer from GitHub release
       id: fetch-installer
       if: inputs.source == 'custom'

--- a/action.yml
+++ b/action.yml
@@ -188,7 +188,7 @@ runs:
         case ${ID} in
         ubuntu)
           case ${VERSION_ID} in
-          16.04|18.04|20.04|22.04)
+          16.04|18.04|20.04|22.04|24.04)
             if [[ "${{ steps.validation.outputs.use_custom_url }}" == "1" ]]; then
               mv "${{ inputs.release-asset-name }}" swift-toolchain.tar.gz
             else

--- a/action.yml
+++ b/action.yml
@@ -145,6 +145,7 @@ runs:
       if: runner.os == 'Windows'
       id: swift-version
       run: |
+        & swift --version
         $SwiftVersionOutput=$(swift --version)
         if ("$SwiftVersionOutput" -match "[\d]+(\.[\d]+){0,2}") {
           $SwiftSemVer=$Matches[0]

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,15 @@ name: Install Swift
 description: Install Swift Release
 
 inputs:
+  source:
+    description: "Where to source the Swift installer. Specify either 'swift.org' or 'custom' (Github release)"
+    required: true
+    default: 'swift.org'
+    type: choice
+    options:
+      - swift.org
+      - custom
+
   # for swift.org toolchains:
   branch:
     description: 'Branch for swift.org builds. Only specifiy when using official Swift toolchains from swift.org'
@@ -37,213 +46,101 @@ inputs:
 runs:
   using: 'composite'
 
-  steps:
-    - name: Validate inputs
-      id: validation
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.github-repo }}" && -n "${{ inputs.release-tag-name }}" && -n "${{ inputs.release-asset-name }}" ]]; then
-          if [[ "${{ runner.os }}" == "Linux" && "${{ inputs.release-asset-name }}" != *.tar.gz ]]; then
-            echo >&2 "::error::inputs Invalid action inputs: release-asset-name has to be a '*.tar.gz' file on Linux platforms."
-            exit 1
-          elif [[ "${{ runner.os }}" == "macOS" && "${{ inputs.release-asset-name }}" != *.pkg ]]; then
-            echo >&2 "::error::inputs Invalid action inputs: release-asset-name has to be a '*.pkg' file on MacOS platforms."
-            exit 1
-          elif [[ "${{ runner.os }}" == "Windows" && "${{ inputs.release-asset-name }}" != *.exe ]]; then
-            echo >&2 "::error::inputs Invalid action inputs: release-asset-name has to be a '*.exe' file on Windows platforms."
-            exit 1
-          fi
-          echo "use_custom_url=1" >> $GITHUB_OUTPUT
-        elif [[ -n "${{ inputs.branch }}" && -n "${{ inputs.tag }}" ]]; then
-          echo "use_custom_url=0" >> $GITHUB_OUTPUT
-        else
-          echo >&2 "::error::inputs Invalid action inputs"
-          echo >&2 "::error::  for a custom Swift toolchain, specify github-repo, release-tag-name and release-asset-name"
-          echo >&2 "::error::  for the official swift.org toolchain, specify only branch and tag"
-          exit 1
-        fi
-
     - name: Fetch installer from GitHub release
-      if: steps.validation.outputs.use_custom_url == 1
-      shell: bash
+      id: fetch-installer
+      if: inputs.source == 'custom'
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        gh release download "${{ inputs.release-tag-name }}" \
-          --repo "${{ inputs.github-repo }}" \
-          --pattern "${{ inputs.release-asset-name }}"
+        gh release download --skip-existing "${{ inputs.release-tag-name }}" --repo "${{ inputs.github-repo }}" --pattern "${{ inputs.release-asset-name }}" --dir ${env:Temp}
+        installer-path=[IO.Path]::Combine(${env:Temp}, ${{ inputs.release-asset-name }}) | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Fetch installer from swift.org
+      id: fetch-installer
+      if: inputs.source == 'swift.org'
+      run: |
+        $URL = if ("${{ inputs.build_arch }}" -eq "amd64") {
+          "https://download.swift.org/${{ inputs.branch }}/windows10/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10.exe"
+        } else {
+          "https://download.swift.org/${{ inputs.branch }}/windows10-${{ inputs.build_arch }}/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10-${{ inputs.build_arch }}.exe"
+        }
+
+        $InvalidCharacters = [IO.Path]::GetInvalidFileNameChars() -Join ''
+        $RE = "[{0}]" -f [RegEx]::Escape($InvalidCharacters)
+        $FileName = [IO.Path]::GetFileName($URL) -Replace $RE
+
+        if ([String]::IsNullOrEmpty($FileName)) {
+          $FileName = [IO.Path]::GetRandomFileName()
+        }
+        $Path = [IO.Path]::Combine(${env:Temp}, $FileName)
+
+        Write-Host "Downloading package from $URL to $Path..."
+        $Retries = 3
+        $RetryInterval = 30
+        do {
+          try {
+            $AttemptStartTime = Get-Date
+            (New-Object System.Net.WebClient).DownloadFile($URL, $Path)
+            $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
+            Write-Host "Package downloaded in $AttemptDuration seconds"
+            break
+          } catch {
+            $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
+            Write-Warning "Package download failed after $AttemptDuration seconds"
+            Write-Warning $_.Exception.Message
+          }
+
+          if ($Retries -eq 1) {
+            $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
+            throw "Package download failed after $Duration seconds"
+          }
+
+          Write-Warning "Waiting $RetryInterval seconds before retrying (retries remaining: $($Retries - 1))..."
+          Start-Sleep -Seconds $RetryInterval
+        } while (--$Retries -gt 0)
+
+        installer-path=$Path | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
     - name: Install Swift ${{ inputs.tag }}
       if: runner.os == 'Windows'
       run: |
-        function Update-EnvironmentVariables {
-          foreach ($level in "Machine", "User") {
-            [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
-              # For Path variables, append the new values, if they're not already in there
-              if ($_.Name -Match 'Path$') {
-                $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
-              }
-              $_
-            } | Set-Content -Path { "Env:$($_.Name)" }
-          }
-        }
+        $Arguments = "${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
-        function Invoke-Download {
-          Param
-          (
-            [Parameter(Mandatory)]
-            [String] $URL,
-            [Alias("Destination")]
-            [Int] $Retries = 20,
-            [Int] $RetryInterval = 30
-          )
-
-          $InvalidCharacters = [IO.Path]::GetInvalidFileNameChars() -Join ''
-          $RE = "[{0}]" -f [RegEx]::Escape($InvalidCharacters)
-          $FileName = [IO.Path]::GetFileName($URL) -Replace $RE
-
-          if ([String]::IsNullOrEmpty($FileName)) {
-            $FileName = [System.IO.Path]::GetRandomFileName()
-          }
-          $Path = Join-Path -Path "${env:Temp}" -ChildPath $FileName
-
-          Write-Host "Downloading package from $URL to $Path..."
-
-          $StartTime = Get-Date
-          do {
-            try {
-              $AttemptStartTime = Get-Date
-              (New-Object System.Net.WebClient).DownloadFile($URL, $Path)
-              $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
-              Write-Host "Package downloaded in $AttemptDuration seconds"
-              break
-            } catch {
-              $AttemptDuration = [math]::Round(($(Get-Date) - $AttemptStartTime).TotalSeconds, 2)
-              Write-Warning "Package download failed after $AttemptDuration seconds"
-              Write-Warning $_.Exception.Message
-            }
-
-            if ($Retries -eq 1) {
-              $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
-              throw "Package download failed after $Duration seconds"
-            }
-
-            Write-Warning "Waiting $RetryInterval seconds before retrying (retries remaining: $($Retries - 1))..."
-            Start-Sleep -Seconds $RetryInterval
-          } while (--$Retries -gt 0)
-
-          return $Path
-        }
-
-        function Verify-Checksum {
-          Param
-          (
-            [Parameter(Mandatory)]
-            [String] $Actual,
-            [Parameter(Mandatory)]
-            [String] $Expected
-          )
-
-          Write-Verbose "Performing Checksum Verification"
-          if ($Actual -eq $Expected) {
-            Write-Verbose "Checksum verification passed"
-          } else {
-            throw "Checksum verification failure (Actual: $Actual vs Expected: $Expected)"
-          }
-        }
-
-        function Invoke-Installer {
-          Param
-          (
-            [Parameter(Mandatory, ParameterSetName = "URL")]
-            [String] $URL,
-            [Parameter(Mandatory, ParameterSetName = "LocalPath")]
-            [String] $LocalPath,
-            [ValidateSet("MSI", "EXE")]
-            [String] $Type,
-            [String[]] $InstallArgs = $null, # Use default for installer format
-            [String[]] $ExtraInstallArgs = @(),
-            [String] $ExpectedSHA256
-          )
-
-          if ($PSCmdlet.ParameterSetName -eq "LocalPath") {
-            if (-not (Test-Path -Path $LocalPath)) {
-              throw "LocalPath parameter is specified, but the file does not exist"
-            }
-            $FilePath = $LocalPath
-          } else {
-            $FileName = [System.IO.Path]::GetFileName($URL)
-            $FilePath = Invoke-Download -URL $URL
-          }
-
-          if ($ExpectedSHA256) {
-            $Hash = (Get-FileHash -Path $FilePath -Algorithm SH256).Hash
-            Verify-Checksum -Actual $Hash -Expected $ExpectedSHA256
-          }
-
-          if (-not $Type) {
-            $Type = ([System.IO.Path]::GetExtension($FilePath)).Replace(".", "").ToUpper()
-          }
-
-          switch ($Type) {
-            "EXE" {
-              if (-not $InstallArgs) { $InstallArgs = @() }
-              $InstallArgs += $ExtraInstallArgs
-            }
-            "MSI" {
-              if (-not $InstallArgs) {
-                Write-Host "Using default MSI arguments: /i, /qn, /norestart"
-                $InstallArgs = @("/i", $FilePath, "/qn", "/norestart")
-              }
-
-              $InstallArgs += $ExtraInstallArgs
-              $FilePath = "msiexec.exe"
-            }
+        $StartTime = Get-Date
+        Write-Host "Installer Arguments: $($Arguments -join ' ')"
+        Write-Host "Starting Install..."
+        try {
+          $Process = Start-Process -FilePath "${{ steps.fetch-installer.outputs.installer-path }}" -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
+          $ExitCode = $Process.ExitCode
+          $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
+          switch ($ExitCode) {
+            0 { Write-Host "Installation successful in $Duration seconds" }
+            3010 { Write-Host "Installation successful in $Duration seconds; reboot required"}
             default {
-              throw "Unknown installer type (${Type}), please specify via `-Type` parameter"
+              Write-Host "Installation process returned unexpected exit code: $ExitCode"
+              Write-Host "Time elapsed: $Duration seconds"
+              exit $ExitCode
             }
           }
+        } catch {
+          $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
+          Write-Host "Installation failed after $Duration seconds: $_"
+          exit 1
+        }
 
-          $InstallArgs += "${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
-
-          $StartTime = Get-Date
-          Write-Host "Installer args: $($InstallArgs -join ' ')"
-          Write-Host "Starting Install..."
-          try {
-            $Process = Start-Process -FilePath $FilePath -ArgumentList $InstallArgs -Wait -PassThru -Verb RunAs
-            $ExitCode = $Process.ExitCode
-            $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
-            switch ($ExitCode) {
-              0 { Write-Host "Installation successful in $Duration seconds" }
-              3010 { Write-Host "Installation successful in $Duration seconds; reboot required"}
-              default {
-                Write-Host "Installation process returned unexpected exit code: $ExitCode"
-                Write-Host "Time elapsed: $Duration seconds"
-                exit $ExitCode
-              }
+        foreach ($level in "Machine", "User") {
+          [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+            # For Path variables, append the new values, if they're not already in there
+            if ($_.Name -Match 'Path$') {
+              $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
             }
-          } catch {
-            $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
-            Write-Host "Installation failed after $Duration seconds: $_"
-            exit 1
-          }
+            $_
+          } | Set-Content -Path { "Env:$($_.Name)" }
         }
-
-        if ("${{ steps.validation.outputs.use_custom_url }}" -eq "1") {
-          Invoke-Installer -LocalPath "${{ inputs.release-asset-name }}" -InstallArgs ("/quiet")
-        } else {
-          if ("${{ inputs.build_arch }}" -eq "amd64") {
-            Invoke-Installer -URL "https://download.swift.org/${{ inputs.branch }}/windows10/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10.exe" -InstallArgs ("/quiet")
-          } else {
-            Invoke-Installer -URL "https://download.swift.org/${{ inputs.branch }}/windows10-${{ inputs.build_arch }}/swift-${{ inputs.tag }}/swift-${{ inputs.tag }}-windows10-${{ inputs.build_arch }}.exe" -InstallArgs ("/quiet")
-          }
-        }
-        Update-EnvironmentVariables
 
         # Reset Path and environment
         echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
-      shell: pwsh
 
     - name: Check Swift version
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
         foreach ($level in "Machine", "User") {
           [Environment]::GetEnvironmentVariables($level).GetEnumerator() | ForEach-Object {
             # For Path variables, append the new values, if they're not already in there
-            if ($_.Name -eq "Path") {
+            if ($_.Name -match 'Path$') {
               $_.Value = "${env:Path};$($_.Value)" -Split ';' | Select -Unique) -Join ';'
             }
             $_

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,7 @@ runs:
       run: |
         gh release download --skip-existing "${{ inputs.release-tag-name }}" --repo "${{ inputs.github-repo }}" --pattern "${{ inputs.release-asset-name }}" --dir ${env:Temp}
         installer-path=[IO.Path]::Combine(${env:Temp}, ${{ inputs.release-asset-name }}) | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+      shell: pwsh
 
     - name: Fetch installer from swift.org
       id: fetch-installer
@@ -141,11 +142,11 @@ runs:
         # Reset Path and environment
         echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
+      shell: pwsh
 
     - name: Check Swift version
       if: runner.os == 'Windows'
       id: swift-version
-      shell: pwsh
       run: |
         $SwiftVersionOutput=$(swift --version)
         if ("$SwiftVersionOutput" -match "[\d]+(\.[\d]+){0,2}") {
@@ -165,6 +166,7 @@ runs:
             "is_newer_than_5_9='false'" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
           }
         }
+      shell: pwsh
 
     - name: VS2022 Compatibility Setup
       if: runner.os == 'Windows' && steps.swift-version.outputs.is_newer_than_5_9 == 'false'

--- a/action.yml
+++ b/action.yml
@@ -118,10 +118,11 @@ runs:
       if: runner.os == 'Windows'
       id: swift-version
       run: |
-        & swift --version
-        $Matches = $(swift --version) -match "\d+.\d+\(.\d+)?"
-        $SwiftVersion = [System.Version]($Matches[0])
-        Write-Output is_newer_than_5_9=$($SwiftVersion -gt [System.Version]"5.9") | Out-File $env:GITHUB_OUTPUT -Append -Encoding UTF8
+        $Output = swift --version
+        if ($Output -match "\d+.\d+\(.\d+)?") {
+          $SwiftVersion = [System.Version]($Matches[0])
+          Write-Output is_newer_than_5_9=$($SwiftVersion -gt [System.Version]"5.9") | Out-File $env:GITHUB_OUTPUT -Append -Encoding UTF8
+        }
       shell: pwsh
 
     - name: VS2022 Compatibility Setup

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   using: 'composite'
   steps:
     - name: Fetch installer from GitHub release
-      id: fetch-installer
+      id: fetch-installer-0
       if: inputs.source == 'custom'
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -57,7 +57,7 @@ runs:
       shell: pwsh
 
     - name: Fetch installer from swift.org
-      id: fetch-installer
+      id: fetch-installer-1
       if: inputs.source == 'swift.org'
       run: |
         $URL = if ("${{ inputs.build_arch }}" -eq "amd64") {
@@ -107,11 +107,13 @@ runs:
       run: |
         $Arguments = "${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
+        $Installer = ${{ steps.fetch-installer-0.outputs.installer-path || steps.fetch-installer-1.outputs.installer-path }}
+
         $StartTime = Get-Date
         Write-Host "Installer Arguments: $($Arguments -join ' ')"
         Write-Host "Starting Install..."
         try {
-          $Process = Start-Process -FilePath "${{ steps.fetch-installer.outputs.installer-path }}" -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
+          $Process = Start-Process -FilePath $Installer -ArgumentList $Arguments -Wait -PassThru -Verb RunAs
           $ExitCode = $Process.ExitCode
           $Duration = [math]::Round(($(Get-Date) - $StartTime).TotalSeconds, 2)
           switch ($ExitCode) {

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
           Start-Sleep -Seconds $RetryInterval
         } while (--$Retries -gt 0)
 
-        installer-path=$Path | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        Write-Output installer-path=$Path | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
       shell: pwsh
 
     - name: Install Swift ${{ inputs.tag }}
@@ -143,7 +143,7 @@ runs:
         }
 
         # Reset Path and environment
-        echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+        Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
       shell: pwsh
 

--- a/action.yml
+++ b/action.yml
@@ -97,8 +97,7 @@ runs:
       if: runner.os == 'Windows'
       run: |
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
-        $Arguments = "${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
-
+        $Arguments = "/quiet ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
         Write-Host "::debug::Installer: $Installer"
         Write-Host "::debug::Installer Arguments: $($Arguments -join ' ')"


### PR DESCRIPTION
1. Split the Download and Install phase
2. Add an explicit option to select the "ParameterSet" for the toolchain source.
3. Inline the (now) single use functions. There is no need to have the ceremony around the function definition and invocation.
4. Specialise the install rules for the particular type of installer shipped for the Swift toolchain. It is unlikely to go to a MSI based installer.

This work prepares the composite action to integrate actions/cache to use the tool cache to amortize the cost of the download of the installer. This becomes more important as the installer size increases.