### PR TITLE
GHA: add the ability to upload install logs on failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,7 @@ runs:
       shell: pwsh
 
     - name: Install Swift ${{ inputs.tag }}
+      id: install-swift
       if: runner.os == 'Windows'
       run: |
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
@@ -111,7 +112,7 @@ runs:
       shell: pwsh
 
     - name: Upload Error Logs
-      if: runner.os == 'Windows' && failure()
+      if: runner.os == 'Windows' && failure() && steps.install-swift.outcome == 'failure'
       uses: actions/upload-artifact@v4
       with:
         name: installer-logs

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
       if: runner.os == 'Windows'
       run: |
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
-        $Arguments = "/quiet ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
+        $Arguments = "/quiet /lv*x ${env:Temp}/install.log ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
         Write-Host "::debug::Installer Arguments: $($Arguments -join ' ')"
         try {
@@ -109,6 +109,13 @@ runs:
         Write-Output "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         Get-ChildItem Env: | ForEach-Object { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
       shell: pwsh
+
+    - name: Upload Error Logs
+      if: runner.os == 'Windows' && failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: installer-logs
+        path: ${env:Temp}/install*.log*
 
     - name: Check Swift version
       if: runner.os == 'Windows'


### PR DESCRIPTION
Attempt to enable logging on installation. If the installation fails, this allows us to upload logs so that we can perform diagnostics on why the install may have failed.