### PR TITLE
GHA: add the ability to update the module map

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -69,3 +69,26 @@ jobs:
       shell: pwsh
       run: |
         -not (Get-Command sourcekit-lsp.exe -ErrorAction SilentlyContinue)
+
+  windows-update-sdk-modules:
+    name: Test SDK module updates on Windows
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: compnerd/gha-setup-vsdevenv@main
+
+    - name: Install Swift with SDK module updates
+      uses: ./
+      with:
+        swift-version: development
+        swift-build: DEVELOPMENT-SNAPSHOT-2025-08-26-a
+        update-sdk-modules: true
+
+    - name: Verify Swift installation
+      run: swift --version
+
+    - name: Smoke test
+      run: |
+        swift package init --type executable
+        swift build

--- a/README.md
+++ b/README.md
@@ -53,12 +53,16 @@ jobs:
   - `swift-version`: (**Note:** this is not a git branch name) the Swift "version" to be installed. This may be either a pre-release branch (e.g. `swift-5.5-branch`), a release branch (e.g. `swift-5.5-release`) or the development branch (`swift-development`).
   - `swift-build`: (**Note:** this is not a git tag name) the actual build tag to install, minus the "`swift-`" prefix. May indicate a release snapshot (e.g. `5.5-DEVELOPMENT-SNAPSHOT-2021-09-18-a`), development snapshot  (e.g. `DEVELOPMENT-SNAPSHOT-2021-09-28-a`), or a release (e.g. `5.5-RELEASE`).
 
-#### Deprecated Parameters (will be removed in a future version):
-  - `branch`: **[DEPRECATED]** Use `swift-version` instead.
-  - `tag`: **[DEPRECATED]** Use `swift-build` instead.
-
 #### When using Swift builds from a Github repository release:
 - `github-repo`: Github repo in "owner/repo" format
 - `release-tag-name`: Release tag name, can be found in `github.com/<owner>/<repo>/releases`
 - `release-asset-name`: Asset name for the Swift installer executable in the release
 - `github-token`: Optional Github token for fetching a release from a private repository
+
+#### Additional Options:
+- `update-sdk-modules`: Update SDK module definitions to latest version after installation (Windows only, default: false)
+- `installer-args`: Additional arguments to pass to the installer, space-delimited
+
+#### Deprecated Parameters (will be removed in a future version):
+  - `branch`: **[DEPRECATED]** Use `swift-version` instead.
+  - `tag`: **[DEPRECATED]** Use `swift-build` instead.

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,11 @@ inputs:
     description: 'Additional arguments to pass to the installer, space-delimited (double quotes are not supported)'
     required: false
     default: ''
+  update-sdk-modules:
+    description: 'Update SDK module definitions to latest version after installation (Windows only)'
+    required: false
+    default: 'false'
+    type: boolean
 
 runs:
   using: 'composite'
@@ -214,6 +219,48 @@ runs:
           Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
         }
         Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+      shell: pwsh
+
+    - name: Update SDK Module Definitions
+      if: runner.os == 'Windows' && inputs.update-sdk-modules == 'true'
+      run: |
+        Write-Host "::notice::Updating SDK module definitions to latest version..."
+
+        $SwiftRoot = Split-Path -Path (Split-Path -Path (Get-Command swift).Source -Parent) -Parent
+
+        $ModuleDefinitions = @{
+          "WinSDK(UM) Module Map" = @{
+            URL = "https://raw.githubusercontent.com/swiftlang/swift/main/stdlib/public/Platform/winsdk.modulemap";
+            Destination = "$([IO.Path]::Combine("${env:SDKROOT}", "usr", "share", "winsdk.modulemap"))";
+          };
+          "UCRT Module Map" = @{
+            URL = "https://raw.githubusercontent.com/swiftlang/swift/main/stdlib/public/Platform/ucrt.modulemap";
+            Destination = "$([IO.Path]::Combine("${env:SDKROOT}", "usr", "share", "ucrt.modulemap"))";
+          };
+          "VCRuntime Module Map" = @{
+            URL = "https://raw.githubusercontent.com/swiftlang/swift/main/stdlib/public/Platform/vcruntime.modulemap";
+            Destination = "$([IO.Path]::Combine("${env:SDKROOT}", "usr", "share", "vcruntime.modulemap"))";
+          };
+          "VCRuntime API Notes" = @{
+            URL = "https://raw.githubusercontent.com/swiftlang/swift/main/stdlib/public/Platform/vcruntime.apinotes";
+            Destination = "$([IO.Path]::Combine("${env:SDKROOT}", "usr", "share", "vcruntime.apinotes"))";
+          };
+          "Clang Module Map" = @{
+            URL = "https://raw.githubusercontent.com/llvm/llvm-project/main/clang/lib/Headers/module.modulemap";
+            Destination = "$([IO.Path]::Combine("$SwiftRoot", "lib", "swift", "clang", "include", "module.modulemap"))";
+          };
+        }
+
+        $ModuleDefinitions.GetEnumerator() | ForEach-Object {
+          Write-Host "::notice::Updating $($_.Value.Destination)"
+          curl.exe --fail --silent --show-error --retry 3 --retry-delay 5 --output "$($_.Value.Destination)" --location $_.Value.URL
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Failed to update $($_.Key)"
+            exit 1
+          }
+        }
+
+        Write-Host "::notice::SDK module definitions updated successfully"
       shell: pwsh
 
     - name: Install Swift


### PR DESCRIPTION
Introduce a new option to update the Windows SDK modularization to the latest version in Swift.