### PR TITLE
Fix installer logging: use Burn /log flag instead of msiexec /lv*x

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -260,7 +260,7 @@ runs:
       run: |
         # Perform installation
         $Installer = [IO.Path]::Combine(${env:Temp}, "installer.exe")
-        $Arguments = "/quiet /lv*x ${env:Temp}/install.log ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
+        $Arguments = "/quiet /log ${env:Temp}\install.log ${{ inputs.installer-args }}".Split(" ", [StringSplitOptions]"RemoveEmptyEntries")
 
         Write-Host "::debug::Installer Arguments: $($Arguments -join ' ')"
         try {


### PR DESCRIPTION
The Swift Windows installer is a WiX Burn bundle, not a raw MSI. The `/lv*x` flag is an msiexec option that Burn silently ignores (`Ignoring unknown argument` in the Burn log), so `install.log` was never created.

This replaces `/lv*x` with `/log`, which is the correct [WiX Burn CLI flag](https://wixtoolset.org/docs/tools/burn/) for specifying the log file path.