### PR TITLE
Update /usr/bin lookup on Linux

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -393,7 +393,9 @@ runs:
       run: |
         tar zxf swift-toolchain.tar.gz -C ${HOME}
         rm -f swift-toolchain.tar.gz
-        echo "${HOME}/usr/bin" >> $GITHUB_PATH
+        SWIFT_PATHS=("$HOME"/swift-*/usr/bin)
+        SWIFT_PATH=${SWIFT_PATHS[0]}
+        echo "${SWIFT_PATH}" >> $GITHUB_PATH
       shell: bash
 
     - name: Install Swift


### PR DESCRIPTION
The toolchain is extracted to `${HOME}`, but the toolchain itself is contained in another `swift-x.y.z` subdirectory. Therefore, `${HOME}/usr/bin` doesn't work. Maybe this has changed recently.