### PR TITLE
Update cache actions to v6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,7 @@ runs:
     - name: Restore cached toolchain
       if: inputs.cache == 'true'
       id: cache-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ${{ runner.os == 'Windows' && steps.cache-key.outputs.path || steps.cache-key-posix.outputs.path }}
         key: ${{ runner.os == 'Windows' && steps.cache-key.outputs.key || steps.cache-key-posix.outputs.key }}
@@ -249,7 +249,7 @@ runs:
 
     - name: Save toolchain to cache
       if: inputs.cache == 'true' && steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: ${{ runner.os == 'Windows' && steps.cache-key.outputs.path || steps.cache-key-posix.outputs.path }}
         key: ${{ runner.os == 'Windows' && steps.cache-key.outputs.key || steps.cache-key-posix.outputs.key }}


### PR DESCRIPTION
Update the split cache restore and save actions from v4 (Node.js 20) to v6 (Node.js 24).

The v6 actions require Actions Runner 2.327.1 or newer; current GitHub-hosted runners satisfy that requirement.

Validation:
- Parsed action.yml and the test workflow as YAML
- git diff --check
- Actionlint 1.7.7 (only the pre-existing checkout@v3 findings remain)